### PR TITLE
Fix handyman commission type error

### DIFF
--- a/app/Http/Resources/API/UserResource.php
+++ b/app/Http/Resources/API/UserResource.php
@@ -78,6 +78,7 @@ class UserResource extends JsonResource
             'designation' => $this->designation,
             'handymantype_id' => $this->handymantype_id,
             'handymantype' => optional($this->handymantype)->name,
+            'handyman_commission' => (string) $this->handyman_commission,
             'known_languages' => $this->known_languages,
             'language_option' => $this->language_option,
             'availability' => $this->availability,

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -62,7 +62,8 @@ class User extends Authenticatable implements HasMedia
         'is_subscribe'            => 'integer',
         'is_available'            => 'integer',
         'slots_for_all_services' => 'integer',
-        'is_email_verified'    => 'integer'
+        'is_email_verified'    => 'integer',
+        'handyman_commission'  => 'string'
     ];
 
     protected static function boot(){


### PR DESCRIPTION
Cast `handyman_commission` to string in API responses to resolve client-side type mismatch error.

---
<a href="https://cursor.com/background-agent?bcId=bc-2c1be6b0-acc5-4549-b454-c2471d8d8993">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-2c1be6b0-acc5-4549-b454-c2471d8d8993">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

