### PR TITLE
Explore payment controller commission logic

### DIFF
--- a/app/Http/Controllers/API/PaymentController.php
+++ b/app/Http/Controllers/API/PaymentController.php
@@ -57,7 +57,7 @@ public function savePayment(Request $request)
         $admin_commission_amount = ($advance_paid_amount * $admin_commission_percentage) / 100;
         $provider_earning = $advance_paid_amount - $admin_commission_amount;
 
-        Wallet::firstOrCreate(['user_id' => $booking->provider_id])->increment('amount', $provider_earning);
+        // Credit only admin on advance; hold provider share until final payment to avoid later clawbacks
         Wallet::firstOrCreate(['user_id' => $admin_user_id])->increment('amount', $admin_commission_amount);
 
         CommissionEarning::create([
@@ -66,24 +66,6 @@ public function savePayment(Request $request)
             'employee_id' => $admin_user_id,
             'commission_amount' => $admin_commission_amount,
             'commission_status' => 'paid',
-        ]);
-
-        CommissionEarning::create([
-            'booking_id' => $booking->id,
-            'user_type' => 'provider',
-            'employee_id' => $booking->provider_id,
-            'commission_amount' => $provider_earning,
-            'commission_status' => 'unpaid',
-        ]);
-
-        ProviderPayout::create([
-            'provider_id' => $booking->provider_id,
-            'amount' => $provider_earning,
-            'payment_method' => 'wallet',
-            'paid_date' => Carbon::now(),
-            'status' => 'paid',
-            'booking_id' => $booking->id,
-            'payment_gateway' => 'wallet',
         ]);
     }
 
@@ -97,84 +79,65 @@ public function savePayment(Request $request)
         $result->total_amount = $remaining_amount;
         $result->save();
 
-        if ($remaining_amount > 0) {
-            // Admin commission
-            $advance_admin_commission = ($advance_paid * $admin_commission_percentage) / 100;
-            $remaining_admin_commission = ($remaining_amount * $admin_commission_percentage) / 100;
+        // Compute totals across the whole booking
+        $total_admin_commission = ($total_amount * $admin_commission_percentage) / 100;
+        $provider_total_earning = $total_amount - $total_admin_commission;
+        $remaining_admin_commission = ($remaining_amount > 0)
+            ? ($remaining_amount * $admin_commission_percentage) / 100
+            : 0;
 
-            $advance_provider_earning = $advance_paid - $advance_admin_commission;
-            $remaining_provider_earning = $remaining_amount - $remaining_admin_commission;
-
-            $total_provider_earning = $advance_provider_earning + $remaining_provider_earning;
-
-            
-            $handymen = BookingHandymanMapping::where('booking_id', $booking->id)->pluck('handyman_id');
-            foreach ($handymen as $handyman_id) {
-                $handyman = User::find($handyman_id);
-
-                if (!$handyman || $handyman->handyman_commission === null) {
-                    continue;
-                }
-
-                // Ensure commission is between 1% and 85%
-                $commission_percent = max(1, min(85, $handyman->handyman_commission));
-
-                // Handyman total share from full provider earning
-                $handyman_total_share = ($total_provider_earning * $commission_percent) / 100;
-
-                // Calculate handyman's share from advance portion
-                $handyman_advance_share = ($advance_provider_earning / $total_provider_earning) * $handyman_total_share;
-                $handyman_remaining_share = $handyman_total_share - $handyman_advance_share;
-
-                // If advance was already paid to provider, deduct handyman's advance share from provider wallet now
-                if ($handyman_advance_share > 0) {
-                    Wallet::firstOrCreate(['user_id' => $booking->provider_id])
-                        ->decrement('amount', $handyman_advance_share);
-                }
-
-                // Deduct handyman remaining share from provider's remaining payout
-                $remaining_provider_earning -= $handyman_remaining_share;
-
-                // Pay full handyman share now
-                Wallet::firstOrCreate(['user_id' => $handyman_id])
-                    ->increment('amount', $handyman_total_share);
-
-                // Record handyman payout
-                HandymanPayout::create([
-                    'handyman_id' => $handyman_id,
-                    'booking_id' => $booking->id,
-                    'amount' => $handyman_total_share,
-                    'status' => 'paid',
-                    'paid_date' => Carbon::now(),
-                    'payment_method' => 'wallet',
-                    'payment_gateway' => 'wallet',
-                ]);
-
-                // Record commission earning for handyman
-                CommissionEarning::create([
-                    'booking_id' => $booking->id,
-                    'user_type' => 'handyman',
-                    'employee_id' => $handyman_id,
-                    'commission_amount' => $handyman_total_share,
-                    'commission_status' => 'paid',
-                ]);
+        // Calculate handyman payouts from provider_total_earning
+        $handymen = BookingHandymanMapping::where('booking_id', $booking->id)->pluck('handyman_id');
+        $handyman_payouts = [];
+        $total_handyman_share = 0;
+        foreach ($handymen as $handyman_id) {
+            $handyman = User::find($handyman_id);
+            if (!$handyman || $handyman->handyman_commission === null) {
+                continue;
             }
+            // Clamp each handyman commission between 1% and 85%
+            $commission_percent = max(1, min(85, $handyman->handyman_commission));
+            $handyman_total_share = ($provider_total_earning * $commission_percent) / 100;
+            $total_handyman_share += $handyman_total_share;
+            $handyman_payouts[] = [
+                'handyman_id' => $handyman_id,
+                'amount' => $handyman_total_share,
+            ];
+        }
 
+        // Final provider earning = provider_total_earning - sum(handymen)
+        $provider_final_earning = $provider_total_earning - $total_handyman_share;
+        if ($provider_final_earning < 0) {
+            // Guard rail: never pay negative. If business rules allow, you can scale down handymen instead.
+            $provider_final_earning = 0;
+        }
 
+        // Pay handymen now
+        foreach ($handyman_payouts as $payout) {
+            Wallet::firstOrCreate(['user_id' => $payout['handyman_id']])->increment('amount', $payout['amount']);
 
-            // Pay remaining part to provider
-            Wallet::firstOrCreate(['user_id' => $booking->provider_id])->increment('amount', $remaining_provider_earning);
-            Wallet::firstOrCreate(['user_id' => $admin_user_id])->increment('amount', $remaining_admin_commission);
-
-            ProviderPayout::create([
-                'provider_id' => $booking->provider_id,
-                'amount' => $remaining_provider_earning,
-                'payment_method' => 'wallet',
-                'paid_date' => Carbon::now(),
-                'status' => 'paid',
+            HandymanPayout::create([
+                'handyman_id' => $payout['handyman_id'],
                 'booking_id' => $booking->id,
+                'amount' => $payout['amount'],
+                'status' => 'paid',
+                'paid_date' => Carbon::now(),
+                'payment_method' => 'wallet',
                 'payment_gateway' => 'wallet',
             ]);
+
+            CommissionEarning::create([
+                'booking_id' => $booking->id,
+                'user_type' => 'handyman',
+                'employee_id' => $payout['handyman_id'],
+                'commission_amount' => $payout['amount'],
+                'commission_status' => 'paid',
+            ]);
+        }
+
+        // Pay remaining admin commission only for the remaining payment now
+        if ($remaining_admin_commission > 0) {
+            Wallet::firstOrCreate(['user_id' => $admin_user_id])->increment('amount', $remaining_admin_commission);
 
             CommissionEarning::create([
                 'booking_id' => $booking->id,
@@ -183,17 +146,30 @@ public function savePayment(Request $request)
                 'commission_amount' => $remaining_admin_commission,
                 'commission_status' => 'paid',
             ]);
-
-            CommissionEarning::create([
-                'booking_id' => $booking->id,
-                'user_type' => 'provider',
-                'employee_id' => $booking->provider_id,
-                'commission_amount' => $remaining_provider_earning,
-                'commission_status' => 'paid',
-            ]);
         }
 
-        // Mark all commissions as paid
+        // Pay provider the final net amount once (advance was held)
+        Wallet::firstOrCreate(['user_id' => $booking->provider_id])->increment('amount', $provider_final_earning);
+
+        ProviderPayout::create([
+            'provider_id' => $booking->provider_id,
+            'amount' => $provider_final_earning,
+            'payment_method' => 'wallet',
+            'paid_date' => Carbon::now(),
+            'status' => 'paid',
+            'booking_id' => $booking->id,
+            'payment_gateway' => 'wallet',
+        ]);
+
+        CommissionEarning::create([
+            'booking_id' => $booking->id,
+            'user_type' => 'provider',
+            'employee_id' => $booking->provider_id,
+            'commission_amount' => $provider_final_earning,
+            'commission_status' => 'paid',
+        ]);
+
+        // Mark all commissions as paid (keeps previous admin advance record consistent)
         CommissionEarning::where('booking_id', $booking->id)->update(['commission_status' => 'paid']);
     }
 
@@ -339,58 +315,29 @@ public function getpaymentall(Request $request)
 
             $booking->update();
 
-            // ✅ Manually split advance payment commission here
+            // ✅ Split advance: pay admin only, hold provider until final payment
             $advance_paid_amount = $request->total_amount;
-
-            // Example: get commission percentage from settings
             $admin_commission_percentage = Setting::getValueByKey('admin_commission_percentage', 'site-setup')->value ?? 10;
-
-            // Calculate
             $admin_commission_amount = ($advance_paid_amount * $admin_commission_percentage) / 100;
-            $provider_earning = $advance_paid_amount - $admin_commission_amount;
 
-            // Add provider earning to wallet
-            $provider_wallet = Wallet::where('user_id', $booking->provider_id)->first();
-            if ($provider_wallet) {
-                $provider_wallet->amount += $provider_earning;
-                $provider_wallet->update();
-            }
-
-            // Add admin commission to admin wallet
+            // Add admin commission to admin wallet only
             $admin_user_id = User::where('user_type', 'admin')->value('id');
             $admin_wallet = Wallet::where('user_id', $admin_user_id)->first();
             if ($admin_wallet) {
                 $admin_wallet->amount += $admin_commission_amount;
                 $admin_wallet->update();
+            } else {
+                Wallet::firstOrCreate(['user_id' => $admin_user_id])->increment('amount', $admin_commission_amount);
             }
 
-            // Optionally record it inside CommissionEarning table (separate record if you want)
+            // Record admin commission only
             CommissionEarning::create([
                 'booking_id' => $booking->id,
                 'user_type' => 'admin',
                 'employee_id' => $admin_user_id,
                 'commission_amount' => $admin_commission_amount,
-                'commission_status' => 'paid', // or 'paid' if you want
+                'commission_status' => 'paid',
             ]);
-
-            CommissionEarning::create([
-                'booking_id' => $booking->id,
-                'user_type' => 'provider',
-                'employee_id' => $booking->provider_id,
-                'commission_amount' => $provider_earning,
-                'commission_status' => 'unpaid',
-            ]);
-
-            ProviderPayout::create([
-                'provider_id' => $booking->provider_id,
-                'amount' => $provider_earning, // Only provider's share of advance payment
-                'payment_method' => 'bank_transfer', // Payment done into wallet
-                'paid_date' => Carbon::now(), // Current timestamp
-                'status' => 'pending', // Payout not sent yet (only earned)
-                'booking_id' => $booking->id, // Optional, if your table has booking_id field
-                'payment_gateway' => 'bank_transfer', // Optional, if your table has this
-            ]);
-
         }
 
 
@@ -408,65 +355,78 @@ public function getpaymentall(Request $request)
             $admin_commission_percentage = Setting::getValueByKey('admin_commission_percentage', 'site-setup')->value ?? 10;
             $admin_user_id = User::where('user_type', 'admin')->value('id');
 
-            if ($remaining_amount > 0) {
-            // Admin commission
-            $advance_admin_commission = ($advance_paid * $admin_commission_percentage) / 100;
-            $remaining_admin_commission = ($remaining_amount * $admin_commission_percentage) / 100;
+            // Compute totals across the whole booking
+            $total_admin_commission = ($total_amount * $admin_commission_percentage) / 100;
+            $provider_total_earning = $total_amount - $total_admin_commission;
+            $remaining_admin_commission = ($remaining_amount > 0)
+                ? ($remaining_amount * $admin_commission_percentage) / 100
+                : 0;
 
-            $advance_provider_earning = $advance_paid - $advance_admin_commission;
-            $remaining_provider_earning = $remaining_amount - $remaining_admin_commission;
-
-            $total_provider_earning = $advance_provider_earning + $remaining_provider_earning;
-
-            // Initialize share deduction
+            // Calculate handyman payouts from provider_total_earning
             $handymen = BookingHandymanMapping::where('booking_id', $booking->id)->pluck('handyman_id');
-           foreach ($handymen as $handyman_id) {
+            $handyman_payouts = [];
+            $total_handyman_share = 0;
+            foreach ($handymen as $handyman_id) {
                 $handyman = User::find($handyman_id);
-
                 if (!$handyman || $handyman->handyman_commission === null) {
                     continue; // Skip if no handyman or no commission set
                 }
-
-                // Ensure commission is between 1% and 85%
                 $commission_percent = max(1, min(85, $handyman->handyman_commission));
-
-                // Calculate handyman share
-                $handyman_share = ($total_provider_earning * $commission_percent) / 100;
-
-                // Deduct from provider's remaining share
-                $remaining_provider_earning -= $handyman_share;
-
-                // Add to handyman wallet
-                Wallet::firstOrCreate(['user_id' => $handyman_id])->increment('amount', $handyman_share);
-
-                // Record payout
-                HandymanPayout::create([
+                $handyman_share = ($provider_total_earning * $commission_percent) / 100;
+                $total_handyman_share += $handyman_share;
+                $handyman_payouts[] = [
                     'handyman_id' => $handyman_id,
-                    'booking_id' => $booking->id,
                     'amount' => $handyman_share,
+                ];
+            }
+
+            $provider_final_earning = $provider_total_earning - $total_handyman_share;
+            if ($provider_final_earning < 0) {
+                $provider_final_earning = 0;
+            }
+
+            // Pay handymen
+            foreach ($handyman_payouts as $payout) {
+                Wallet::firstOrCreate(['user_id' => $payout['handyman_id']])->increment('amount', $payout['amount']);
+
+                HandymanPayout::create([
+                    'handyman_id' => $payout['handyman_id'],
+                    'booking_id' => $booking->id,
+                    'amount' => $payout['amount'],
                     'status' => 'paid',
                     'paid_date' => Carbon::now(),
                     'payment_method' => 'wallet',
                     'payment_gateway' => 'wallet',
                 ]);
 
-                // Record commission earning
                 CommissionEarning::create([
                     'booking_id' => $booking->id,
                     'user_type' => 'handyman',
-                    'employee_id' => $handyman_id,
-                    'commission_amount' => $handyman_share,
+                    'employee_id' => $payout['handyman_id'],
+                    'commission_amount' => $payout['amount'],
                     'commission_status' => 'paid',
                 ]);
             }
 
-            // Pay remaining part to provider
-            Wallet::firstOrCreate(['user_id' => $booking->provider_id])->increment('amount', $remaining_provider_earning);
-            Wallet::firstOrCreate(['user_id' => $admin_user_id])->increment('amount', $remaining_admin_commission);
+            // Pay remaining admin commission only for remaining amount
+            if ($remaining_admin_commission > 0) {
+                Wallet::firstOrCreate(['user_id' => $admin_user_id])->increment('amount', $remaining_admin_commission);
+
+                CommissionEarning::create([
+                    'booking_id' => $booking->id,
+                    'user_type' => 'admin',
+                    'employee_id' => $admin_user_id,
+                    'commission_amount' => $remaining_admin_commission,
+                    'commission_status' => 'paid',
+                ]);
+            }
+
+            // Pay provider once with final amount
+            Wallet::firstOrCreate(['user_id' => $booking->provider_id])->increment('amount', $provider_final_earning);
 
             ProviderPayout::create([
                 'provider_id' => $booking->provider_id,
-                'amount' => $remaining_provider_earning,
+                'amount' => $provider_final_earning,
                 'payment_method' => 'wallet',
                 'paid_date' => Carbon::now(),
                 'status' => 'paid',
@@ -476,20 +436,11 @@ public function getpaymentall(Request $request)
 
             CommissionEarning::create([
                 'booking_id' => $booking->id,
-                'user_type' => 'admin',
-                'employee_id' => $admin_user_id,
-                'commission_amount' => $remaining_admin_commission,
-                'commission_status' => 'paid',
-            ]);
-
-            CommissionEarning::create([
-                'booking_id' => $booking->id,
                 'user_type' => 'provider',
                 'employee_id' => $booking->provider_id,
-                'commission_amount' => $remaining_provider_earning,
+                'commission_amount' => $provider_final_earning,
                 'commission_status' => 'paid',
             ]);
-        }
 
             CommissionEarning::where('booking_id', $booking->id)->update(['commission_status' => 'paid']);
         }


### PR DESCRIPTION
Adjust payment flow to prevent negative provider payouts by holding provider advance earnings until final payment and deducting handyman commissions from the total booking earnings.

The previous logic could result in negative provider payouts if a high handyman commission was applied after the provider had already received their share of an advance payment. This change ensures that the provider's final earning is calculated only after all commissions (admin and handyman) are accounted for, preventing such discrepancies.

---
<a href="https://cursor.com/background-agent?bcId=bc-9b986f18-0cca-49b5-9d70-fa63db381699">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-9b986f18-0cca-49b5-9d70-fa63db381699">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

