### PR TITLE
Explore postjob request feature

### DIFF
--- a/app/Http/Controllers/PostJobRequestController.php
+++ b/app/Http/Controllers/PostJobRequestController.php
@@ -675,6 +675,10 @@ class PostJobRequestController extends Controller
 
         $bid = PostJobBid::findOrFail($id);
 
+        // Define commonly used ids
+        $adminUser  = User::where('user_type', 'admin')->first();
+        $providerId = $bid->provider_id;
+
         // 🔹 Verify session with Stripe
         try {
             $session = getstripePaymnetId($sessionId, 'stripe');


### PR DESCRIPTION
Fixes "Undefined variable $providerId" error in Stripe payment callback by defining `$providerId` and `$adminUser`.

---
<a href="https://cursor.com/background-agent?bcId=bc-3d2c32e1-745b-4937-9883-c3e4f855d898"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-3d2c32e1-745b-4937-9883-c3e4f855d898"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

